### PR TITLE
fix(isMPA): fix isMPA value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
           const templatePath = templateOption
             ? resolve(templateOption)
             : resolve('public/index.html')
-          const isMPA = Object.keys(config.build.rollupOptions.input || {}).length > 0
+          const isMPA = typeof config.build.rollupOptions.input !== 'string' && Object.keys(config.build.rollupOptions.input || {}).length > 0
           let content = await getHtmlContent({
             pagesDir: options.pagesDir,
             pageName,
@@ -76,7 +76,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
      */
     resolveId(id) {
       if (id.endsWith('.html')) {
-        const isMPA = Object.keys(config.build.rollupOptions.input || {}).length > 0
+        const isMPA = typeof config.build.rollupOptions.input !== 'string' && Object.keys(config.build.rollupOptions.input || {}).length > 0
         if (!isMPA) {
           return `${PREFIX}/${path.basename(id)}`
         } else {
@@ -97,7 +97,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
         const page = options.pages[pageName] || {}
         const templateOption = page.template
         const templatePath = templateOption ? resolve(templateOption) : resolve('public/index.html')
-        const isMPA = Object.keys(config.build?.rollupOptions.input || {}).length > 0
+        const isMPA = typeof config.build?.rollupOptions.input !== 'string' && Object.keys(config.build?.rollupOptions.input || {}).length > 0
         return getHtmlContent({
           pagesDir: options.pagesDir,
           pageName,
@@ -117,7 +117,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
     },
     /** for build */
     closeBundle() {
-      const isMPA = Object.keys(config.build?.rollupOptions.input || {}).length > 0
+      const isMPA = typeof config.build?.rollupOptions.input !== 'string' && Object.keys(config.build?.rollupOptions.input || {}).length > 0
       // MPA handled by vite-plugin-mpa
       if (!isMPA) {
         const root = config.root || process.cwd()


### PR DESCRIPTION
In [vite@2.7.0 changes]( https://github.com/vitejs/vite/blob/v2.7.0/packages/vite/CHANGELOG.md#270-beta4-2021-11-12), the variable `build.rollupOptions.input` has been changed. 

If the app isn't a MPA, the old value of `build.rollupOptions.input` is `undefined`, but the new value is the path of the entry html file, whose type is string. 

So I add type check for every isMPA assignment.