### PR TITLE
feat(): support two type for options data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-plugin-html-template",
+  "name": "vite-plugin-html-template-guo",
   "version": "1.1.3",
   "description": "html template for vite",
   "main": "dist/index.js",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -97,3 +97,26 @@ export async function getHtmlContent(payload: Payload) {
   })
   return html
 }
+
+export function dfs(keys: string[], value: any, res: Record<string, any>) {
+  if (keys.length) {
+    const strItem = keys.shift()
+    if (!keys.length) {
+      res[strItem!] = value
+    } else {
+      const tmp = res[strItem!] ? res[strItem!] : (res[strItem!] = {})
+      dfs(keys, value, tmp)
+    }
+  }
+  return res
+}
+
+export function dfs2(rebuildData: Record<string, any>, key: string, value: Record<string, any>) {
+  const tmp = rebuildData[key] ? rebuildData[key] : (rebuildData[key] = {})
+  if (Object.prototype.toString.call(value).slice(8, -1) === 'Object') {
+    const nextKey = Object.keys(value)[0]
+    dfs2(tmp, nextKey, value[nextKey])
+  } else {
+    rebuildData[key] = value
+  }
+}


### PR DESCRIPTION
pr with #20 only concern 
```
data: {
  'a.b.c': 123
}

```
but this is not support
```
data: {
  'a.b.c': 123,
  'e.d.f': 234
}
```
now this pr fix this problem and support both type about options.data
```
data: {
  'a.b.c': '123',
   e: {
    d: {
      f: 123
    }
  }
}
```