### PR TITLE
feat: support nested entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from 'vite'
 import type { UserOptions } from './lib/options'
 import path from 'path'
 import shell from 'shelljs'
-import { last } from 'lodash'
-import { getHtmlContent, dfs, dfs2 } from './lib/utils'
+import { getHtmlContent, dfs, dfs2, findPageName } from './lib/utils'
 import { name } from '../package.json'
 
 const resolve = (p: string) => path.resolve(process.cwd(), p)
@@ -99,7 +98,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
         if (!isMPA) {
           return `${PREFIX}/${path.basename(id)}`
         } else {
-          const pageName = last(path.dirname(id).split(isWin32 ? '\\' : '/')) || ''
+          const pageName = findPageName(id, options.pagesDir)
           if (pageName in (config.build.rollupOptions.input as any)) {
             return isWin32
               ? id.replace(/\\/g, '/')
@@ -118,7 +117,7 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
       ) {
         const idNoPrefix = id.slice(PREFIX.length)
         // resolveId checked isWin32 already
-        const pageName = last(path.dirname(id).split('/')) || ''
+        const pageName = findPageName(id, options.pagesDir)
 
         const page = options.pages[pageName] || {}
         const templateOption = page.template

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,9 @@
 import type { UserOptions } from './options'
 import { promises as fs } from 'fs'
-import { template } from 'lodash'
+import { template, last } from 'lodash'
+import path from 'path'
+
+const isWin32 = require('os').platform() === 'win32'
 
 /** read original template content */
 async function readHtmlTemplate(templatePath: string) {
@@ -119,4 +122,12 @@ export function dfs2(rebuildData: Record<string, any>, key: string, value: Recor
   } else {
     rebuildData[key] = value
   }
+}
+
+export function findPageName(id: string, pageDir: string) {
+  const pDir = isWin32 ? pageDir.replace('/', '\\') : pageDir
+  const pathWithoutPageDir = last(path.dirname(id).split(pDir)) || ''
+
+  // remove leading \\ or /
+  return isWin32 ? pathWithoutPageDir.replace(/^\\/, '') : pathWithoutPageDir.replace(/^\//, '')
 }


### PR DESCRIPTION
add support for nested entry:

for nested pages like: ./src/home/subpagea

the pageName of an entry is the whole dir after option.pagesDir, not the last one of split('/')