### PR TITLE
fix(windows): use id with backslash when resolving page name (#34)

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -125,8 +125,9 @@ export function dfs2(rebuildData: Record<string, any>, key: string, value: Recor
 }
 
 export function findPageName(id: string, pageDir: string) {
-  const pDir = isWin32 ? pageDir.replace('/', '\\') : pageDir
-  const pathWithoutPageDir = last(path.dirname(id).split(pDir)) || ''
+  const pId = isWin32 ? id.replace(/\//g, '\\') : id
+  const pDir = isWin32 ? pageDir.replace(/\//g, '\\') : pageDir
+  const pathWithoutPageDir = last(path.dirname(pId).split(pDir)) || ''
 
   // remove leading \\ or /
   return isWin32 ? pathWithoutPageDir.replace(/^\\/, '') : pathWithoutPageDir.replace(/^\//, '')


### PR DESCRIPTION
This is a fix for #34. It seems it is related 1.2.0 update.

Found that argument `id` on `resolveId` and `load` hook has different separator on windows.

- resolveId: `C:\Users\username\...`
- load: `C:/Users/username/...`

This fix modified `findePageName` to ensure both `id` and `pageDir` use the correct separator on windows.
