### PR TITLE
feat(template): support template for all pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,8 @@ export default function htmlTemplate(userOptions: UserOptions = {}): Plugin {
             return url.match(new RegExp(`${options.pagesDir}/(.*)/`))?.[1] || 'index'
           })()
           const page = options.pages[pageName] || {}
-          const templateOption = page.template
+          // page template has higher priority than template in options
+          const templateOption = page.template || options.template
           const templatePath = templateOption
             ? resolve(templateOption)
             : resolve('public/index.html')

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -42,6 +42,11 @@ export interface Options {
    * @default '/src/main'
    */
   entry?: string
+  /**
+   * template path for all pages, has lower priority than `template` in `pages`
+   * @default public/index.html
+   */
+  template?: string
 }
 
 export type UserOptions = Partial<Options>


### PR DESCRIPTION
Add support to assign template path for all all pages.

with this feature, we can assign template path for all all pages in options, instead of repeat in every pages